### PR TITLE
增加一个参数，控制改表后是否保留 shadow table

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -34,6 +34,7 @@ rest_key:
 # general config
 log_dir: /tmp/shift/
 pt_osc_path: pt-online-schema-change
+enable_trash: ${RUNNER_ENABLE_TRASH:-true}
 pending_drops_db: ${RUNNER_PENDING_DROPS_DB}
 log_sync_interval: ${RUNNER_LOG_SYNC_INTERVAL:-10}
 state_sync_interval: ${RUNNER_STATE_SYNC_INTERVAL:-10}

--- a/runner/config/development-config.yaml
+++ b/runner/config/development-config.yaml
@@ -14,6 +14,7 @@ rest_key:
 # general config
 log_dir: /tmp/shift/
 pt_osc_path: pt-online-schema-change
+enable_trash: true
 pending_drops_db:
 log_sync_interval: 10
 state_sync_interval: 10

--- a/runner/config/production-config.yaml
+++ b/runner/config/production-config.yaml
@@ -14,6 +14,7 @@ rest_key:
 # general config
 log_dir: /tmp/shift/
 pt_osc_path: pt-online-schema-change
+enable_trash: true
 pending_drops_db:
 log_sync_interval: 10
 state_sync_interval: 10

--- a/runner/config/staging-config.yaml
+++ b/runner/config/staging-config.yaml
@@ -14,6 +14,7 @@ rest_key:
 # general config
 log_dir: /tmp/shift/
 pt_osc_path: pt-online-schema-change
+enable_trash: true
 pending_drops_db:
 log_sync_interval: 10
 state_sync_interval: 10

--- a/runner/pkg/migration/migration.go
+++ b/runner/pkg/migration/migration.go
@@ -69,6 +69,7 @@ var (
 	RunWriteQuery            = (*Migration).RunWriteQuery
 	DirectDrop               = (*Migration).DirectDrop
 	MoveToPendingDrops       = (*Migration).MoveToPendingDrops
+	MoveToBlackHole          = (*Migration).MoveToBlackHole
 	DropTriggers             = (*Migration).DropTriggers
 	CleanUp                  = (*Migration).CleanUp
 	TimestampedTable         = timestampedTable
@@ -91,6 +92,7 @@ type Migration struct {
 	RunType        int
 	Mode           int
 	Action         int
+	EnableTrash    bool
 	PendingDropsDb string
 	CustomOptions  map[string]string
 }
@@ -296,6 +298,12 @@ func (migration *Migration) MoveToPendingDrops(sourceTable, destTable string) er
 	return nil
 }
 
+// MoveToBlackhole drops the table
+func (migration *Migration) MoveToBlackHole(table string) error {
+	query := "DROP TABLE " + table
+	return RunWriteQuery(migration, query)
+}
+
 // TimestampedTable prefixes a table name with a timestamp
 func timestampedTable(table string) string {
 	t := time.Now()
@@ -323,7 +331,11 @@ func (migration *Migration) CleanUp() error {
 		return err
 	}
 	pdTable := TimestampedTable(migTable)
-	err = MoveToPendingDrops(migration, migTable, pdTable)
+	if migration.EnableTrash {
+		err = MoveToPendingDrops(migration, migTable, pdTable)
+	} else {
+		err = MoveToBlackHole(migration, pdTable)
+	}
 	if err != nil {
 		return err
 	}

--- a/runner/pkg/migration/migration.go
+++ b/runner/pkg/migration/migration.go
@@ -330,11 +330,11 @@ func (migration *Migration) CleanUp() error {
 	if err != nil {
 		return err
 	}
-	pdTable := TimestampedTable(migTable)
 	if migration.EnableTrash {
+		pdTable := TimestampedTable(migTable)
 		err = MoveToPendingDrops(migration, migTable, pdTable)
 	} else {
-		err = MoveToBlackHole(migration, pdTable)
+		err = MoveToBlackHole(migration, migTable)
 	}
 	if err != nil {
 		return err

--- a/runner/pkg/migration/migration_test.go
+++ b/runner/pkg/migration/migration_test.go
@@ -525,24 +525,32 @@ func TestMoveToPendingDrops(t *testing.T) {
 var cleanUpTests = []struct {
 	dropTriggersError error
 	getMigTableError  error
+	enableTrash       bool
 	migTable          string
 	pdTable           string
 	moveToPDError     error
+	moveToBHError     error
 	expectedError     error
 }{
 	// error dropping triggers
-	{ErrQueryFailed{}, nil, "", "", nil, ErrQueryFailed{}},
+	{ErrQueryFailed{}, nil, true, "", "", nil, nil, ErrQueryFailed{}},
 	// error getting mig table
-	{nil, ErrStateFile, "", "", nil, ErrStateFile},
+	{nil, ErrStateFile, true, "", "", nil, nil, ErrStateFile},
 	// error moving to pending drops
-	{nil, nil, "_t1_new", "20150826_t1_new", ErrQueryFailed{}, ErrQueryFailed{}},
+	{nil, nil, true, "_t1_new", "20150826_t1_new", ErrQueryFailed{}, nil, ErrQueryFailed{}},
+	// error moving to blackhole
+	{nil, nil, false, "_t1_new", "20150826_t1_new", nil, ErrQueryFailed{}, ErrQueryFailed{}},
+	// success with trash
+	{nil, nil, true, "_t1_new", "20150826_t1_new", nil, ErrQueryFailed{}, nil},
+	// success without trash
+	{nil, nil, false, "_t1_new", "20150826_t1_new", ErrQueryFailed{}, nil, nil},
 	// success
-	{nil, nil, "_t1_new", "20150826_t1_new", nil, nil},
+	{nil, nil, true, "_t1_new", "20150826_t1_new", nil, nil, nil},
 }
 
 func TestCleanUp(t *testing.T) {
 	for _, tt := range cleanUpTests {
-		migration := &Migration{Table: "t1"}
+		migration := &Migration{Table: "t1", EnableTrash: tt.enableTrash}
 
 		DropTriggers = func(mig *Migration, table string) error {
 			if table != "t1" {
@@ -568,6 +576,12 @@ func TestCleanUp(t *testing.T) {
 			}
 
 			return tt.moveToPDError
+		}
+		MoveToBlackHole = func(mig *Migration, table string) error {
+			if table != tt.pdTable {
+				t.Errorf("dropped table = %v, want %v", table, tt.pdTable)
+			}
+			return tt.moveToBHError
 		}
 
 		actualError := migration.CleanUp()

--- a/runner/pkg/runner/runner.go
+++ b/runner/pkg/runner/runner.go
@@ -70,6 +70,7 @@ var (
 	DirectDrop          = (*migration.Migration).DirectDrop
 	SwapOscTables       = (*migration.Migration).SwapOscTables
 	MoveToPendingDrops  = (*migration.Migration).MoveToPendingDrops
+	MoveToBlackHole     = (*migration.Migration).MoveToBlackHole
 	CleanUp             = (*migration.Migration).CleanUp
 	RunWriteQuery       = (*migration.Migration).RunWriteQuery
 
@@ -97,6 +98,7 @@ type runner struct {
 	MysqlRootCA       string `yaml:"mysql_rootCA"`
 	MysqlDefaultsFile string `yaml:"mysql_defaults_file"`
 	LogDir            string `yaml:"log_dir"`
+	EnableTrash       bool   `yaml:"enable_trash"`
 	PendingDropsDb    string `yaml:"pending_drops_db"`
 	PtOscPath         string `yaml:"pt_osc_path"`
 	HostOverride      string `yaml:"host_override"`
@@ -312,6 +314,7 @@ func (runner *runner) unstageRunnableMigration(currentMigration rest.RestRespons
 			FilesDir:       filesDir,
 			StateFile:      stateFile,
 			LogFile:        logFile,
+			EnableTrash:    runner.EnableTrash,
 			PendingDropsDb: runner.PendingDropsDb,
 			CustomOptions:  customOptions,
 		}
@@ -533,12 +536,19 @@ func (runner *runner) runMigrationDirectDrop(currentMigration *migration.Migrati
 			return
 		}
 	} else {
-		// rename old table to the pending_drops database instead of actually
-		// dropping it
-		pdTable := migration.TimestampedTable(currentMigration.Table)
-		err = MoveToPendingDrops(currentMigration, currentMigration.Table, pdTable)
-		if err != nil {
-			return
+		if currentMigration.EnableTrash {
+			// rename old table to the pending_drops database instead of actually
+			// dropping it
+			pdTable := migration.TimestampedTable(currentMigration.Table)
+			err = MoveToPendingDrops(currentMigration, currentMigration.Table, pdTable)
+			if err != nil {
+				return
+			}
+		} else {
+			err = DirectDrop(currentMigration)
+			if err != nil {
+				return
+			}
 		}
 	}
 
@@ -626,11 +636,20 @@ func (runner *runner) renameTablesStep(currentMigration *migration.Migration) er
 	if err != nil {
 		return err
 	}
-	// rename old table to pending_drops database.
-	// if the pending_drops database is the same as the database for the
-	// migration, skip this step.
-	if currentMigration.Database != currentMigration.PendingDropsDb {
-		err = MoveToPendingDrops(currentMigration, oldTable, oldTable)
+
+	if currentMigration.EnableTrash {
+		// rename old table to pending_drops database.
+		// if the pending_drops database is the same as the database for the
+		// migration, skip this step.
+		if currentMigration.Database != currentMigration.PendingDropsDb {
+			err = MoveToPendingDrops(currentMigration, oldTable, oldTable)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		// trash disabled, just drop oldtable
+		err = MoveToBlackHole(currentMigration, oldTable)
 		if err != nil {
 			return err
 		}
@@ -1145,7 +1164,7 @@ func (runner *runner) updateMigrationCopyPercentage(currentMigration *migration.
 		}
 		_, err := runner.RestClient.Update(urlParams)
 		if err != nil {
-			glog.Errorf("mig_id=%d: error updating copy percentage (error: %s). Continuing anyway", migrationId, err)
+			glog.Errorf("mig_id=%s: error updating copy percentage (error: %s). Continuing anyway", migrationId, err)
 		}
 	}
 }


### PR DESCRIPTION
新增一个参数 RUNNER_ENABLE_TRASH，默认为 true

为 true 时，删表/通过 pt-osc 改表时会保留一个以日期为前缀的 shadow table，保存到 RUNNER_PENDING_DROPS_DB db 中
为 false 时，不会保留 shadow table

```
$ go test -count=1 ./migration ./runner                                        
ok  	github.com/square/shift/runner/pkg/migration	0.021s
ok  	github.com/square/shift/runner/pkg/runner	16.086s
```